### PR TITLE
Issue:#5105 added authorization vault to verify public access on S3 resources

### DIFF
--- a/lib/auth/Vault.js
+++ b/lib/auth/Vault.js
@@ -217,7 +217,29 @@ class Vault {
                 return callback(null, result);
             });
     }
-
+    /** verifyPublicResource -- call Vault to verify the public access on resource
+     * @param {object} params - the authentication parameters as returned by
+     *                          auth.extractParams
+     * @param {RequestContext [] | null} requestContexts -
+     * an array of RequestContext or null if authenticaiton of a chunk
+     * in streamingv4 auth
+     * instances which contain information for policy authorization check
+     * @param {function} callback - callback with either error or an object
+     * with canonicalID keys and email address values
+    */
+    verifyPublicResource(params, requestContexts, callback) {
+        let serializedRCs;
+        if (requestContexts) {
+            serializedRCs = requestContexts.map(rc => rc.serialize());
+        }
+        this.client.verifyPublicResource(
+            params,
+            {
+                requestContext: serializedRCs
+            },
+            callback
+        );
+    }
     /** checkPolicies -- call Vault to evaluate policies
      * @param {object} requestContextParams - parameters needed to construct
      * requestContext in Vault

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -117,7 +117,7 @@ function doAuth(request, log, cb, awsService, requestContexts) {
     if (res.err) {
         return cb(res.err);
     } else if (res.params instanceof AuthInfo) {
-        return cb(null, res.params);
+        return vault.verifyPublicResource(res.params, requestContexts, cb);
     }
     if (requestContexts) {
         requestContexts.forEach(requestContext => {


### PR DESCRIPTION
If someone will try to access the resources with public url(without signature), bitpod auth middleware with verify the $everyone check on the resource or on it's parent folders.